### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import * as wcb from 'webcryptobox'
 In modern browser which support es6 modules, just include [the file](./webcryptobox.js) directly:
 ```html
 <script type=module>
-  import * as wcb from './webcryptobox.js'
+  import * as wcb from './node_modules/webcryptobox/index.js';
 </script>
 ```
 
@@ -38,10 +38,10 @@ Now you can dance with Webcryptobox like this:
 ```js
 const alice = await wcb.generateKeyPair()
 const bob = await wcb.generateKeyPair()
-const text = 'Nobody else can offer me something, something heart felt like you did it.'
+const text = 'Test message'
 const message = wcb.decodeText(text)
-const box = await wcb.encryptTo({ message, alice.privateKey, bob.publicKey })
-const decryptedBox = await wcb.decryptFrom({ box, bob.privateKey, alice.publicKey })
+const box = await wcb.encryptTo({ message, privateKey: alice.privateKey, publicKey: bob.publicKey })
+const decryptedBox = await wcb.decryptFrom({ box, privateKey: bob.privateKey, publicKey: alice.publicKey })
 const decryptedText = wcb.encodeText(decryptedBox)
 ```
 


### PR DESCRIPTION
Hi Johannes, thanks for the lovely library. I've been using it successfully in my own project after I realized I was writing the exact same thing you already wrote! I recently decided to add `webcryptobox` is a "real" npm dependency rather than just copy the javascript. However, your instructions in the readme don't work for the browser. The problem seems to be that the library only creates a `node_modules/webcryptobox/index.js`. 

Then, in the code, some of your api needs `privateKey` and `publicKey` named properties.
You can see a demo of the working code here: https://simpatico.io/crypto

Hope this helps